### PR TITLE
Update risk_credentials_exposed.serverless.yaml with all possible eve…

### DIFF
--- a/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
+++ b/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
@@ -17,7 +17,11 @@ Resources:
           eventTypeCategory:
             - "issue"
           eventTypeCode:
+            - "AWS_RISK_CREDENTIALS_COMPROMISED"
+            - "AWS_RISK_CREDENTIALS_COMPROMISE_SUSPECTED"
             - "AWS_RISK_CREDENTIALS_EXPOSED"
+            - "AWS_RISK_CREDENTIALS_EXPOSURE_SUSPECTED"
+            - "AWS_RISK_IAM_QUARANTINE"
       State: "ENABLED"
       Targets: 
         - 


### PR DESCRIPTION
Added all possible event codes related to IAM access key exposure - 
           "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_COMPROMISED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_COMPROMISE_SUSPECTED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_EXPOSED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_EXPOSURE_SUSPECTED", 
            "service": "RISK"

*Issue #, if available:*
The existing eventcode in CFT is not detecting IAM key exposure events.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
