### PR TITLE
Updating lambda runtime to python 3.11

### DIFF
--- a/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
+++ b/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
@@ -116,7 +116,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: delete_access_key_pair.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaDeleteAccessKeyPairRole.Arn
  
@@ -124,7 +124,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lookup_cloudtrail_events.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaLookupCloudTrailEventsRole.Arn
  
@@ -132,7 +132,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: notify_security.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaSnsPublishRole.Arn
       Environment:


### PR DESCRIPTION
Tested and verified in local env

Updating lambda runtime to python 3.11


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
